### PR TITLE
Adds spanish translation \o/

### DIFF
--- a/translations/spanish.php
+++ b/translations/spanish.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'd88d6b865ab77786075f28c80b293156' => 'Casi, pero no todavía :(',
+    'a1386a1de1a4d2efbff582b2d2874b2c' => 'Pronto...',
+    '86aa3b4e1da49715bee032b02b24dfef' => '¡Es el fin de semana! \o/',
+    '3accdebf72a75061a33b3bd33d54a28a' => 'Oficialmente no, pero es como si lo fuera.',
+    'cbdf2122065fb2a68b1c14fd82482810' => 'Se terminó... :(',
+    'c215c811b8791e49ccd39c177f58bd8d' => 'Y perdemos un feriado este fin de semana :(',
+    '3ab2f6f6b038e237765335ad0cea43fc' => 'Pero mañana, no trabajamos \o/',
+    '98ed3a487cf9f80c10bdafe2189fc531' => 'De hecho, sí. ¡Es casi el fin de semana! \o/',
+    '7514b1a515e6b5494236f32e24d34b6d' => 'Pero no trabajamos \o/',
+    '62d17a9dfd12f3ec8817c58a81b38669' => 'No.'
+];


### PR DESCRIPTION
Not much to explain about the changes. I just cloned, duplicated the translations/default.php file and replaced with Spanish translations to all sentences.